### PR TITLE
fix: fix toggle buttons not reacting

### DIFF
--- a/src/context/volume-context.js
+++ b/src/context/volume-context.js
@@ -43,19 +43,31 @@ function volumeReducer(state, action) {
 
   switch (action.type) {
     case "TOGGLE_MEASUREMENT": {
-      state.options = { ...state.options, measurement: action.payload };
-      state.path = getPath();
-      return state;
+      return {
+        options: {
+          ...state.options,
+          measurement: action.payload
+        },
+        path: getPath()
+      };
     }
     case "TOGGLE_SEASON": {
-      state.options = { ...state.options, season: action.payload };
-      state.path = getPath();
-      return state;
+      return {
+        options: {
+          ...state.options,
+          season: action.payload
+        },
+        path: getPath()
+      };
     }
     case "TOGGLE_TIDE": {
-      state.options = { ...state.options, tide: action.payload };
-      state.path = getPath();
-      return state;
+      return {
+        options: {
+          ...state.options,
+          tide: action.payload
+        },
+        path: getPath()
+      };
     }
     default: {
       throw new Error(`Unhandled action type: ${action.type}`);


### PR DESCRIPTION
`volumeReducer` returns a new state object (instead of mutating original) which triggers a re-render of components that use `VolumeContext`. 

Fixes a bug where the `ToggleButtons` were not changing state when clicked

closes issue #25 